### PR TITLE
Potential fix to Cron Pipeline not sending emails due to null email_list field

### DIFF
--- a/src/com/qaprosoft/jenkins/pipeline/impl/QARunner.groovy
+++ b/src/com/qaprosoft/jenkins/pipeline/impl/QARunner.groovy
@@ -993,7 +993,7 @@ public class QARunner extends AbstractRunner {
                             pipelineMap.put("env", supportedEnv)
                             pipelineMap.put("order", orderNum)
                             pipelineMap.put("BuildPriority", priorityNum)
-                            Executor.putNotNullWithSplit(pipelineMap, "email_list", emailList)
+                            Executor.putNotNullWithSplit(pipelineMap, "emailList", emailList)
                             Executor.putNotNullWithSplit(pipelineMap, "executionMode", executionMode)
                             Executor.putNotNull(pipelineMap, "overrideFields", overrideFields)
 
@@ -1085,10 +1085,12 @@ public class QARunner extends AbstractRunner {
 
             //add current build params from cron
             for (param in Configuration.getParams()) {
-                if ("false".equalsIgnoreCase(param.getValue().toString()) || "true".equalsIgnoreCase(param.getValue().toString())) {
-                    jobParams.add(context.booleanParam(name: param.getKey(), value: param.getValue()))
-                } else {
-                    jobParams.add(context.string(name: param.getKey(), value: param.getValue()))
+                if (param.getValue() != null) {
+                    if ("false".equalsIgnoreCase(param.getValue().toString()) || "true".equalsIgnoreCase(param.getValue().toString())) {
+                        jobParams.add(context.booleanParam(name: param.getKey(), value: param.getValue()))
+                    } else {
+                        jobParams.add(context.string(name: param.getKey(), value: param.getValue()))
+                    }
                 }
             }
 

--- a/src/com/qaprosoft/jenkins/pipeline/impl/QARunner.groovy
+++ b/src/com/qaprosoft/jenkins/pipeline/impl/QARunner.groovy
@@ -993,7 +993,7 @@ public class QARunner extends AbstractRunner {
                             pipelineMap.put("env", supportedEnv)
                             pipelineMap.put("order", orderNum)
                             pipelineMap.put("BuildPriority", priorityNum)
-                            Executor.putNotNullWithSplit(pipelineMap, "emailList", emailList)
+                            Executor.putNotNullWithSplit(pipelineMap, "email_list", emailList)
                             Executor.putNotNullWithSplit(pipelineMap, "executionMode", executionMode)
                             Executor.putNotNull(pipelineMap, "overrideFields", overrideFields)
 


### PR DESCRIPTION
The issue here is by default the cron pipeline has a null email_list.  Now in earlier versions of the pipeline this was fine, it looks like the current issue may have been introduced in 3.1.  The thought with this tweak here is when the Cron Pipeline parameters are iterated that it will then remove any values which are null and in this particular scenario the only value that is really null for the Cron Pipeline Parameters would be the email_list.  This should get the email's properly sending again.