### PR TITLE
Adding in a trim to the testCaseId as there is a possibility the annotation is passed with a space after the comma between multiple

### DIFF
--- a/src/com/qaprosoft/integration/qtest/QTestUpdater.groovy
+++ b/src/com/qaprosoft/integration/qtest/QTestUpdater.groovy
@@ -141,7 +141,7 @@ class QTestUpdater {
                     parsedIntegrationInfo.projectId = projectId
                 }
                 Map testCase = new HashMap()
-                testCase.case_id = testCaseId
+                testCase.case_id = testCaseId.trim()
                 testCase.status = testInfo.status
                 testCase.testURL = "${integration.zafiraServiceUrl}/#!/tests/runs/${integration.testRunId}/info/${testInfo.id}"
                 testCasesMap.put(testCaseId, testCase)


### PR DESCRIPTION
Adding in a quick trim to the testCaseId in case someone does a QTestCases(id = "123, 542") which could be a common occurrence.