### PR TITLE
no scm for gitlab

### DIFF
--- a/src/com/qaprosoft/jenkins/pipeline/tools/scm/github/GitHub.groovy
+++ b/src/com/qaprosoft/jenkins/pipeline/tools/scm/github/GitHub.groovy
@@ -23,6 +23,8 @@ class GitHub implements ISCM {
 			gitHtmlUrl = "https://\${GITHUB_HOST}/scm/\${GITHUB_ORGANIZATION}/${Configuration.get("repo")}"
 		} else if(scmHost.contains("bitbucket")) {
             gitHtmlUrl = "https://\${GITHUB_HOST}/\${GITHUB_ORGANIZATION}/${Configuration.get("repo")}"
+        } else if (scmHost.contains("gitlab")) {
+            gitHtmlUrl = "https://\${GITHUB_HOST}/\${GITHUB_ORGANIZATION}/${Configuration.get("repo")}"
         } else if(scmHost.contains("io")) {
             gitHtmlUrl = "https://\${GITHUB_HOST}/scm/\${GITHUB_ORGANIZATION}/${Configuration.get("repo")}"
         } else {


### PR DESCRIPTION
our domain name contains "io" and this adds "/scm/" to the gitlab repository url, which should not.