### PR TITLE
Android / Amazon Fire TV Support

### DIFF
--- a/src/com/qaprosoft/jenkins/jobdsl/factory/pipeline/TestJobFactory.groovy
+++ b/src/com/qaprosoft/jenkins/jobdsl/factory/pipeline/TestJobFactory.groovy
@@ -123,6 +123,11 @@ public class TestJobFactory extends PipelineFactory {
                         booleanParam('enableVideo', enableVideo, 'Enable video recording')
                         configure stringParam('capabilities', getSuiteParameter("platformName=ANDROID;deviceName=" + defaultMobilePool, "capabilities", currentSuite), 'Reserved for any semicolon separated W3C driver capabilities.')
                         break
+                    case "android-tv":
+                        booleanParam('auto_screenshot', autoScreenshot, 'Generate screenshots automatically during the test')
+                        booleanParam('enableVideo', enableVideo, 'Enable video recording')
+                        configure stringParam('capabilities', getSuiteParameter("platformName=ANDROIDTV;deviceName=" + defaultMobilePool, "capabilities", currentSuite), 'Reserved for any semicolon separated W3C driver capabilities.')
+                        break
                     case "android-web":
                         booleanParam('auto_screenshot', autoScreenshot, 'Generate screenshots automatically during the test')
                         booleanParam('enableVideo', enableVideo, 'Enable video recording')

--- a/src/com/qaprosoft/jenkins/pipeline/runner/maven/TestNG.groovy
+++ b/src/com/qaprosoft/jenkins/pipeline/runner/maven/TestNG.groovy
@@ -655,6 +655,10 @@ public class TestNG extends Runner {
                 logger.info("Suite Type: ANDROID")
                 Configuration.set("node", "android")
                 break;
+            case "android-tv":
+                logger.info("Suite Type: ANDROID TV")
+                Configuration.set("node", "android-tv")
+                break;   
             case "ios":
             case "ios-web":
                 logger.info("Suite Type: iOS")
@@ -694,9 +698,9 @@ public class TestNG extends Runner {
 
     protected void prepareForMobile() {
         logger.info("Runner->prepareForMobile")
-        def platform = Configuration.get("job_type")
+        def platform = Configuration.get("job_type").toLowerCase()
 
-        if (platform.equalsIgnoreCase("android")) {
+        if (platform.contains("android")) {
             prepareForAndroid()
         } else if (platform.equalsIgnoreCase("ios")) {
             prepareForiOS()
@@ -893,8 +897,8 @@ public class TestNG extends Runner {
     }
 
     protected def addVideoStreamingCapability(message, capabilityName, capabilityValue) {
-        def node = Configuration.get("node")
-        if ("web".equalsIgnoreCase(node) || "android".equalsIgnoreCase(node)) {
+        def node = Configuration.get("node").toLowerCase()
+        if ("web".equalsIgnoreCase(node) || node.contains("android")) {
             logger.info(message)
             Configuration.set(capabilityName, capabilityValue)
         }


### PR DESCRIPTION
This is the first go at adding in support for Android / Amazon Fire TV in the pipeline.

Changes:

- Add in jobType of 'android-tv', follows closely to existing Android pipeline values.
- Added in platformName of "ANDROIDTV", will have to double check against appium-device tweaks.
- Added in setting node of 'android-tv' for running to differentiate from a mobile node.
- Tweaking prepareForMobile slightly to allow for Android/AndroidTV as Android TV uses the same logic overall and this is just the first go to see if all this works.